### PR TITLE
Draft: Selecting Push / Pull Target

### DIFF
--- a/ferrous-game/Assets/Scenes/Main Scene.unity
+++ b/ferrous-game/Assets/Scenes/Main Scene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0.18028352, g: 0.22571376, b: 0.3069224, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -2097,6 +2097,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   GunActiveSFX: {fileID: 1340318749}
+  rayDist: 40
   pullForce: 10
 --- !u!114 &963194232
 MonoBehaviour:

--- a/ferrous-game/Assets/Scripts/ObjectPuller.cs
+++ b/ferrous-game/Assets/Scripts/ObjectPuller.cs
@@ -25,6 +25,24 @@ public class ObjectPuller : MonoBehaviour
 
     void Update()
     {
+
+
+        if (Input.GetKeyDown(KeyCode.E))
+        {
+            RaycastHit hit;
+            // generates a ray in the look direction
+            Ray ray = mainCamera.ScreenPointToRay(Input.mousePosition);
+            // instead of origin -> destination, use the defined ray
+            if (Physics.Raycast(ray, out hit, rayDist)) 
+            {
+                if (hit.collider.CompareTag("Metal"))
+                {
+                    Debug.Log("Selected Metal");
+                }
+            }
+        }
+
+        if (Input.GetMouseButton(0) || Input.GetMouseButton(1)) // Change this to your desired input method
         if (Input.GetButton("Fire1") || Input.GetAxisRaw("Fire1") > 0 || Input.GetButton("Fire2") || Input.GetAxisRaw("Fire2") > 0)
         {
             if (!soundPlayed)

--- a/ferrous-game/Assets/Scripts/ObjectPuller.cs
+++ b/ferrous-game/Assets/Scripts/ObjectPuller.cs
@@ -12,20 +12,54 @@ public class ObjectPuller : MonoBehaviour
 
     private Rigidbody rb;
     private Camera mainCamera;
-    private Transform interactableObject;
+    private Transform _playerTransform;
     private bool soundPlayed;
 
+    [Header("Select")]
+    public float rayDist;
+
+    [Header("Push/Pull")]
     public float pullForce = 10f;
+    private Rigidbody selectedObject;
+    private bool isSelected;
 
     void Start()
     {
         rb = GetComponent<Rigidbody>();
         mainCamera = Camera.main;
+        _playerTransform = GameObject.Find("Player").transform;
     }
 
     void Update()
     {
+        selectObject();
+        if (isSelected)
+        {
+            getPushPullInput();
+        }
 
+    }
+    private void LateUpdate()
+    {
+        if (isPulling && isSelected)
+        {
+            Debug.Log("Pulling");
+            Vector3 pullDirection = (_playerTransform.position - selectedObject.position).normalized;
+            pullDirection = new Vector3(pullDirection.x, 0f, pullDirection.z);
+            selectedObject.GetComponent<Rigidbody>().AddForce(pullDirection * pullForce);
+        }
+        else if (isPushing && isSelected)
+        {
+            Debug.Log("Pushing");
+            Vector3 pushDirection = -(mainCamera.transform.position - selectedObject.position).normalized;
+            Debug.Log(pushDirection);
+            Debug.DrawRay(mainCamera.transform.position, pushDirection, Color.red);
+            pushDirection = new Vector3(pushDirection.x, 0f, pushDirection.z);
+            selectedObject.GetComponent<Rigidbody>().AddForce(pushDirection * pullForce);
+        }
+    }
+    private void selectObject()
+    {
 
         if (Input.GetKeyDown(KeyCode.E))
         {
@@ -33,61 +67,68 @@ public class ObjectPuller : MonoBehaviour
             // generates a ray in the look direction
             Ray ray = mainCamera.ScreenPointToRay(Input.mousePosition);
             // instead of origin -> destination, use the defined ray
-            if (Physics.Raycast(ray, out hit, rayDist)) 
+            if (Physics.Raycast(ray, out hit, rayDist))
             {
                 if (hit.collider.CompareTag("Metal"))
                 {
-                    Debug.Log("Selected Metal");
+                    GameObject prevSelectedObject;
+                    if (selectedObject != null)
+                    {
+                        // compare prev and new selected
+                        prevSelectedObject = selectedObject.gameObject;
+                        selectedObject = hit.rigidbody;
+                        if (Object.ReferenceEquals(prevSelectedObject, selectedObject.gameObject))
+                        {
+                            // de-select the object
+                            selectedObject.useGravity = true;
+                            selectedObject = null;
+                            isSelected = false;
+                        }
+                        else
+                        {
+                            // turn gravity back on for the previous object
+                            prevSelectedObject.GetComponent<Rigidbody>().useGravity = true;
+                            // make the current object hover
+                            selectedObject.useGravity = false;
+                            selectedObject.AddForce(Vector3.up * 75f);
+                        }
+                    }
+                    else
+                    {
+                        // no object was previously selected, select the current one
+                        selectedObject = hit.rigidbody;
+                        selectedObject.useGravity = false;
+                        selectedObject.AddForce(Vector3.up * 75f);
+                        isSelected = true;
+                    }
+
+
                 }
             }
         }
+    }
 
-        if (Input.GetMouseButton(0) || Input.GetMouseButton(1)) // Change this to your desired input method
+    private void getPushPullInput()
+    {
         if (Input.GetButton("Fire1") || Input.GetAxisRaw("Fire1") > 0 || Input.GetButton("Fire2") || Input.GetAxisRaw("Fire2") > 0)
         {
-            if (!soundPlayed)
-            {
-                GunActiveSFX.Play();
-                soundPlayed = true;
-            }
-            RaycastHit hit;
-            Ray ray = mainCamera.ScreenPointToRay(Input.mousePosition);
-            Debug.DrawRay(transform.position, transform.forward, Color.green);
+            if (Input.GetMouseButton(0) || Input.GetAxisRaw("Fire1") > 0.1f) { isPulling = true; Debug.Log("pulling"); }
+            else if (Input.GetMouseButton(1) || Input.GetAxisRaw("Fire2") > 0.1f) { isPushing = true; }
 
-            if (Physics.Raycast(ray, out hit))
-            {
-                if (hit.collider.CompareTag("Metal"))
-                {
-                    Debug.Log(Input.GetMouseButton(0));
-                    if (Input.GetMouseButton(0) || Input.GetAxisRaw("Fire1") > 0.1f) { isPulling = true; }
-                    else if (Input.GetMouseButton(1) || Input.GetAxisRaw("Fire2") > 0.1f) { isPushing = true; }
-                    interactableObject = hit.transform;
-                }
-            }
+            
         }
 
-        if (Input.GetAxisRaw("Fire1") < 0.1f && !Input.GetMouseButton(0)) 
-        { 
+        if (Input.GetAxisRaw("Fire1") < 0.1f && !Input.GetMouseButton(0))
+        {
+            Debug.Log("not pulling");
             isPulling = false;
             soundPlayed = false;
-        } 
-        if (Input.GetAxisRaw("Fire2") < 0.1f && !Input.GetMouseButton(1)) 
-        { 
+        }
+        if (Input.GetAxisRaw("Fire2") < 0.1f && !Input.GetMouseButton(1))
+        {
+            Debug.Log("not pushing");
             isPushing = false;
             soundPlayed = false;
-        }
-
-        if (isPulling)
-        {
-            Debug.Log("Pulling");
-            Vector3 pullDirection = (mainCamera.transform.position - interactableObject.position).normalized;
-            interactableObject.GetComponent<Rigidbody>().AddForce(pullDirection * pullForce);
-        }   
-        else if (isPushing)
-        {
-            Debug.Log("Pushing");
-            Vector3 pullDirection = -(mainCamera.transform.position - interactableObject.position).normalized;
-            interactableObject.GetComponent<Rigidbody>().AddForce(pullDirection * pullForce);
         }
     }
 }


### PR DESCRIPTION
working select a block -> ability to push / pull, can no longer look at a block and push / pull

IMPORTANT: DO NOT MERGE, we need to playtest and also discuss if we want this feature moving forwards, especially with objects that are _already_ magnetized and don't move (player moves instead)

might be good to merge now, added a public bool on main camera that lets us flip between