### PR TITLE
add DeactivateObject method in BaseSwitch

### DIFF
--- a/ferrous-game/Assets/Scripts/Mechanics/BaseSwitch.cs
+++ b/ferrous-game/Assets/Scripts/Mechanics/BaseSwitch.cs
@@ -8,7 +8,7 @@ namespace Ferrous.Mechanics
     {
         private bool activated = false;
 
-        public bool Activated             //¶¨ÒåÊôÐÔ£¬ÓÃÀ´²Ù×÷Ë½ÓÐ×Ö¶Îid
+        public bool Activated             //ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ô£ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ë½ï¿½ï¿½ï¿½Ö¶ï¿½id
         {
             get
             {
@@ -20,6 +20,11 @@ namespace Ferrous.Mechanics
             }
         }
         public abstract void ActivateObject();
+
+        public virtual void DeactivateObject()
+        {
+            throw new System.NotImplementedException();
+        }
     }
 }
 

--- a/ferrous-game/Assets/Scripts/Mechanics/PlayerPlate.cs
+++ b/ferrous-game/Assets/Scripts/Mechanics/PlayerPlate.cs
@@ -19,12 +19,21 @@ namespace Ferrous
             {
                 ActivateObject();
             }
+            else
+            {
+                DeactivateObject();
+            }
         }
         
         public override void ActivateObject()
         {
             Activated = true;
             onActivation.Invoke();
+        }
+
+        public override void DeactivateObject()
+        {
+            Activated = false;
         }
 
         private void OnTriggerEnter(Collider collision)

--- a/ferrous-game/Assets/Scripts/Mechanics/PressurePlate.cs
+++ b/ferrous-game/Assets/Scripts/Mechanics/PressurePlate.cs
@@ -15,11 +15,24 @@ namespace Ferrous.Mechanics
             onActivation.Invoke();
         }
 
+        public override void DeactivateObject()
+        {
+            Activated = false;
+        }
+
         private void OnTriggerEnter(Collider collision)
         {
             if (collision.tag == "Metal")
             {
                 ActivateObject();
+            }
+        }
+
+        private void OnTriggerExit(Collider collision)
+        {
+            if (collision.tag == "Metal")
+            {
+                DeactivateObject();
             }
         }
 


### PR DESCRIPTION
add DeactivateObject method in BaseSwitch that will be called to set Activated=false. 

previously, the pressure plates needed to be touched by the metal blocks but could be taken off and the door would still open when all of them were touched.
fixes this: now all pressure plates need to be weighted by a metal block for door to open